### PR TITLE
Modification des paramètres gérés par le simulateur serveur d'appel contextuel

### DIFF
--- a/TestServer-AppelContextuel/src/main/java/appelContextuel/ParameterList.java
+++ b/TestServer-AppelContextuel/src/main/java/appelContextuel/ParameterList.java
@@ -28,11 +28,10 @@ public class ParameterList {
 	private final Map<String, Map<String, String>> paramsCache = new HashMap<>();
 
 	private String[] paramsMandatory = {"patient.identifier.value", "patient.identifier.system", "patient.name.family", "patient.name.given", "patient.gender", 
-			"patient.birthdate", "address.district", "informationetoppositionconsultation", "patientid", "patientidissuer"};  
+			"patient.birthdate", "address.district", "informationetconsentement", "patientid", "patientidissuer"};  
 
 	private String[] paramsAll = {"patient.identifier.value", "patient.identifier.system", "patient.name.family", "patient.name.given", "patient.gender", 
-			"patient.birthdate", "address.district", "informationetoppositionconsultation", "patientid", "patientidissuer", 
-			"studyinstanceuid", "modality", "accessionnumber", "accessionnumberissuer", "studydate", "anatomicregion", "situation"};
+			"patient.birthdate", "address.district", "informationetconsentement", "patientid", "patientidissuer", "situation"};
 
 	@ConfigProperty(name = "server.hostname")
 	String hostname;


### PR DESCRIPTION
Ajustement des paramètres gérés par le simulateur serveur d'appel contextuel afin de s'aligner avec la dernière version de la spécification projet DRIMBox